### PR TITLE
Destroy session upon reset

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -144,3 +144,13 @@ MoEngage.prototype.identify = function(identify) {
 MoEngage.prototype.track = function(track) {
   this._client.track_event(track.event(), track.properties());
 };
+
+/**
+ * Reset
+ *
+ * @api public
+ */
+
+MoEngage.prototype.reset = function() {
+  this._client.destroy_session();
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -25,7 +25,6 @@ describe('MoEngage', function() {
   afterEach(function() {
     analytics.restore();
     analytics.reset();
-    // moengage.reset();
     sandbox();
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -25,7 +25,7 @@ describe('MoEngage', function() {
   afterEach(function() {
     analytics.restore();
     analytics.reset();
-    moengage.reset();
+    // moengage.reset();
     sandbox();
   });
 
@@ -146,6 +146,18 @@ describe('MoEngage', function() {
         };
         analytics.track('The Song', properties);
         analytics.called(moengage._client.track_event, 'The Song', properties);
+      });
+    });
+
+    describe('#reset', function() {
+      beforeEach(function() {
+        analytics.stub(moengage._client, 'destroy_session');
+      });
+
+      it('should destroy session upon reset', function() {
+        analytics.identify('justin');
+        moengage.reset();
+        analytics.called(moengage._client.destroy_session);
       });
     });
   });


### PR DESCRIPTION
The MoEngage integration currently doesn't have a way to destroy the session upon a logout. This enables the user to do this by calling `analytics.reset`.