### PR TITLE
add destroy session condition in track calls

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -142,6 +142,13 @@ MoEngage.prototype.identify = function(identify) {
  */
 
 MoEngage.prototype.track = function(track) {
+
+  // Important: MoEngage require you to manually call reset to wipe the unique id for the session
+  // if you don't do this and call add_unique_user_id w/ a different userId, it will overwrite the previous user's
+  // unique id and all their traits so we need to manually check if it's a new user since `analytics.reset()` is not
+  // mapped for ajs integrations
+  if (this.initializedAnonymousId !== track.anonymousId()) this._client.destroy_session();
+
   this._client.track_event(track.event(), track.properties());
 };
 


### PR DESCRIPTION
This condition to call the integration's destroy session method needs to exist in track calls especially if they are invoked prior to identify (where the condition already exists).  